### PR TITLE
Removing additional post type name appended as class in <article>

### DIFF
--- a/templates/author.twig
+++ b/templates/author.twig
@@ -14,7 +14,7 @@
         {% endif %}
       </div>
       {% for post in posts %}
-        <article class="{{ post.class }} post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+        <article class="{{ post.class }}" id="post-{{ post.ID }}">
           <h2 class="post-title"><a href="{{ post.link }}">{{ post.title }}</a></h2>
           <div class="meta">
             <div class="date">{{ post.date }}</div>

--- a/templates/components/loop.twig
+++ b/templates/components/loop.twig
@@ -1,6 +1,6 @@
 {% for post in posts %}
 
-    <article class="{{ post.class }} post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+    <article class="{{ post.class }}" id="post-{{ post.ID }}">
       <header>
         {% if post.thumbnail %}
           <div class="thumbnail">

--- a/templates/page.twig
+++ b/templates/page.twig
@@ -4,7 +4,7 @@
   <!-- Provided by templates/page.twig -->
   <p>{{ __('View author: ', 'gesso') }} <a href="{{ user.link }}">{{ user.name }}</a></p>
 
-	<article class="{{ post.class }} post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+	<article class="{{ post.class }}" id="post-{{ post.ID }}">
 		<h1 class="page-title">{{ post.title }}</h1>
 		{{ post.content }}
 	</article>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
   <!-- Provided by templates/single.twig -->
-  <article class="{{ post.class }} post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+  <article class="{{ post.class }}" id="post-{{ post.ID }}">
     <h2 class="post-title">{{ post.title }}</h2>
     <div class="author">{{ __('Authored by', 'gesso') }}
       <a href="{{ post.author.link }}">{{ post.author.display_name }}</a>

--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -2,7 +2,7 @@
 
 {% block content %}
   <!-- Provided by templates/tease-post.twig -->
-  <article class="{{ post.class }} post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+  <article class="{{ post.class }}" id="post-{{ post.ID }}">
     <h2 class="post-title"><a href="{{ post.link }}">{{ post.title }}</a></h2>
     <p>{{ post.get_preview }}</p>
     {% if post.get_thumbnail %}

--- a/templates/tease.twig
+++ b/templates/tease.twig
@@ -1,6 +1,6 @@
 {% block content %}
   <!-- Provided by templates/tease.twig -->
-  <article class="{{ post.class }} post-type-{{ post.post_type }}" id="post-{{ post.ID }}">
+  <article class="{{ post.class }}" id="post-{{ post.ID }}">
     <h2 class="post-title"><a href="{{ post.link }}">{{ post.title }}</a></h2>
     <p>{{ post.get_preview }}</p>
     {% if post.get_thumbnail %}


### PR DESCRIPTION
Unless there's any other reason I might be missing, using `post-type-{{ post.post_type }}`  would be kind of redundant because `{{ post.class }}` already provides dynamically a class with the post type name like `type-post`, `type-page` or e.g. `type-product` for a CPT named Product.