### PR TITLE
Removing placeholders to register new CPT and custom Taxonomies

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -290,17 +290,7 @@ class StarterSite extends TimberSite {
     add_theme_support( 'menus' );
     add_filter( 'timber_context', array( $this, 'add_to_context' ) );
     add_filter( 'get_twig', array( $this, 'add_to_twig' ) );
-    add_action( 'init', array( $this, 'register_post_types' ) );
-    add_action( 'init', array( $this, 'register_taxonomies' ) );
     parent::__construct();
-  }
-
-  function register_post_types() {
-    //this is where you can register custom post types
-  }
-
-  function register_taxonomies() {
-    //this is where you can register custom taxonomies
   }
 
   function add_to_context( $context ) {


### PR DESCRIPTION
Despite those hooks works perfectly in template's functions.php file, is not a good practice to declare those from the theme files. That should be declared in a custom plugin territory or by using plugins like [Custom Post Type UI](https://wordpress.org/plugins/custom-post-type-ui/) or other similar's that already exists out there.

Imagine if the theme by any chance becomes inactive, or it get's replaced by a new one, those CPT and/or custom Taxonomies will be lost unless they are carried over, which will add an extra mile to the workload. Keeping that functionality in a custom plugin just for it, or in a [MU Plugin](https://codex.wordpress.org/Must_Use_Plugins) is always the best choice.

http://www.wpbeginner.com/opinion/wordpress-custom-post-types-debate-functions-php-or-plugins/

http://www.wpbeginner.com/beginners-guide/what-why-and-how-tos-of-creating-a-site-specific-wordpress-plugin/

https://www.sitepoint.com/wordpress-mu-plugins/