### PR TITLE
Gesso BEM Gallery markup

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -320,7 +320,7 @@ new StarterSite();
 function gesso_bem_gallery( $gallery, $attr ) {
 
   // [ thumbnail | medium | large | full ]
-  $size   = 'large'; 
+  $size   = 'thumbnail'; 
   $output = '<div class="gallery">';
   $posts  = get_posts( array( 'include' => $attr['ids'], 'post_type' => 'attachment' ) );
 

--- a/functions.php
+++ b/functions.php
@@ -309,3 +309,29 @@ class StarterSite extends TimberSite {
 }
 
 new StarterSite();
+
+
+/**
+ * Override default WordPress gallery markup, outputs in BEM format.
+ * @param string $gallery
+ * @param array $attr
+ * @return string
+ */
+function gesso_bem_gallery( $gallery, $attr ) {
+
+  // [ thumbnail | medium | large | full ]
+  $size   = 'large'; 
+  $output = "<div class=\"gallery\">";
+  $posts  = get_posts( array( 'include' => $attr['ids'], 'post_type' => 'attachment' ) );
+
+  foreach ( $posts as $image_post ) {
+    $src = wp_get_attachment_image_src( $image_post->ID, $size );
+    $output .= "<div class=\"gallery-item\"><a href=" . $src[0] . "><img class=\"gallery-item__image\" src='" . $src[0] . "'></a>";
+    $output .= "<div class=\"gallery-item__caption\">" . $image_post->post_excerpt . "</div></div>";
+  }
+
+  $output .= "</div>";
+
+  return $output;
+}
+add_filter( 'post_gallery', 'gesso_bem_gallery', 10, 2 );

--- a/functions.php
+++ b/functions.php
@@ -321,16 +321,17 @@ function gesso_bem_gallery( $gallery, $attr ) {
 
   // [ thumbnail | medium | large | full ]
   $size   = 'large'; 
-  $output = "<div class=\"gallery\">";
+  $output = '<div class="gallery">';
   $posts  = get_posts( array( 'include' => $attr['ids'], 'post_type' => 'attachment' ) );
 
   foreach ( $posts as $image_post ) {
-    $src = wp_get_attachment_image_src( $image_post->ID, $size );
-    $output .= "<div class=\"gallery-item\"><a href=" . $src[0] . "><img class=\"gallery-item__image\" src='" . $src[0] . "'></a>";
-    $output .= "<div class=\"gallery-item__caption\">" . $image_post->post_excerpt . "</div></div>";
+    $src      = wp_get_attachment_image_src( $image_post->ID, $size );
+    $alt_text = get_post_meta( $image_post->ID, '_wp_attachment_image_alt', true );
+    $output .= '<div class="gallery-item"><a href="' . $src[0] . '"><img alt="' . $alt_text . '" class="gallery-item__image" src="' . $src[0] . '"></a>';
+    $output .= '<div class="gallery-item__caption">' . $image_post->post_excerpt . '</div></div>';
   }
 
-  $output .= "</div>";
+  $output .= '</div>';
 
   return $output;
 }


### PR DESCRIPTION
This filter will reformat the default WordPress gallery to something more appropriate for this theme following a BEM format.

Basically it will replace this markup:

```
<div id="gallery-1" class="gallery galleryid-61 gallery-columns-3 gallery-size-large">
    <figure class="gallery-item">
        <div class="gallery-icon landscape">
            <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/curabitur-arcu-erat.jpg"<img width="480" height="360" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/curabitur-arcu-erat.jpg" class="attachment-large size-large" alt="" aria-describedby="gallery-1-46" srcset="http://vagrant.byf1.io/wp-content/uploads/2017/08/curabitur-arcu-erat.jpg 480w, http://vagrant.byf1.io/wp-content/uploads/2017/08/curabitur-arcu-erat-250x188.jpg 250w, http://vagrant.byf1.io/wp-content/uploads/2017/08/curabitur-arcu-erat-120x90.jpg 120w" sizes="(max-width: 480px) 100vw, 480px"></a>
	</div>
	<figcaption class="wp-caption-text gallery-caption" id="gallery-1-46">The Caption</figcaption>
    </figure>
    <figure class="gallery-item">
        <div class="gallery-icon landscape">
	    <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/proin-eget-tortor-risus.jpg"><img width="480" height="360" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/proin-eget-tortor-risus.jpg" class="attachment-large size-large" alt="" aria-describedby="gallery-1-42" srcset="http://vagrant.byf1.io/wp-content/uploads/2017/08/proin-eget-tortor-risus.jpg 480w, http://vagrant.byf1.io/wp-content/uploads/2017/08/proin-eget-tortor-risus-250x188.jpg 250w, http://vagrant.byf1.io/wp-content/uploads/2017/08/proin-eget-tortor-risus-120x90.jpg 120w" sizes="(max-width: 480px) 100vw, 480px"></a>
	</div>
	<figcaption class="wp-caption-text gallery-caption" id="gallery-1-42">The Caption</figcaption>
    </figure>
    <figure class="gallery-item">
        <div class="gallery-icon landscape">
	    <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/vestibulum-ac-diam-sit-amet.jpg"><img width="480" height="360" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/vestibulum-ac-diam-sit-amet.jpg" class="attachment-large size-large" alt="" aria-describedby="gallery-1-40" srcset="http://vagrant.byf1.io/wp-content/uploads/2017/08/vestibulum-ac-diam-sit-amet.jpg 480w, http://vagrant.byf1.io/wp-content/uploads/2017/08/vestibulum-ac-diam-sit-amet-250x188.jpg 250w, http://vagrant.byf1.io/wp-content/uploads/2017/08/vestibulum-ac-diam-sit-amet-120x90.jpg 120w" sizes="(max-width: 480px) 100vw, 480px"></a>
	</div>
	<figcaption class="wp-caption-text gallery-caption" id="gallery-1-40">The Caption</figcaption>
    </figure>
    <figure class="gallery-item">
        <div class="gallery-icon landscape">
	    <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa.jpg"><img width="700" height="394" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa-700x394.jpg" class="attachment-large size-large" alt="" aria-describedby="gallery-1-17" srcset="http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa-700x394.jpg 700w, http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa-250x141.jpg 250w, http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa-768x432.jpg 768w, http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa-120x68.jpg 120w, http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa.jpg 1280w" sizes="(max-width: 700px) 100vw, 700px"></a>
	</div>
	<figcaption class="wp-caption-text gallery-caption" id="gallery-1-17">The Caption</figcaption>
    </figure>
    <figure class="gallery-item">
        <div class="gallery-icon landscape">
	    <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/sed-porttitor-lectus-nibh.jpg"><img width="480" height="360" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/sed-porttitor-lectus-nibh.jpg" class="attachment-large size-large" alt="" aria-describedby="gallery-1-23" srcset="http://vagrant.byf1.io/wp-content/uploads/2017/08/sed-porttitor-lectus-nibh.jpg 480w, http://vagrant.byf1.io/wp-content/uploads/2017/08/sed-porttitor-lectus-nibh-250x188.jpg 250w, http://vagrant.byf1.io/wp-content/uploads/2017/08/sed-porttitor-lectus-nibh-120x90.jpg 120w" sizes="(max-width: 480px) 100vw, 480px"></a>
	</div>
	<figcaption class="wp-caption-text gallery-caption" id="gallery-1-23">The Caption</figcaption>
    </figure>
</div>
```

By something following BEM convention like this:
```
<div class="gallery">
    <div class="gallery-item">
        <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/curabitur-arcu-erat.jpg"><img class="gallery-item__image" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/curabitur-arcu-erat.jpg"></a>
        <div class="gallery-item__caption">The Caption</div>
    </div>
    <div class="gallery-item">
        <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/proin-eget-tortor-risus.jpg"><img class="gallery-item__image" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/proin-eget-tortor-risus.jpg"></a>
        <div class="gallery-item__caption">The Caption</div>
    </div>
    <div class="gallery-item">
        <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/vestibulum-ac-diam-sit-amet.jpg"><img class="gallery-item__image" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/vestibulum-ac-diam-sit-amet.jpg"></a>
        <div class="gallery-item__caption">The Caption</div>
    </div>
    <div class="gallery-item">
        <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/sed-porttitor-lectus-nibh.jpg"><img class="gallery-item__image" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/sed-porttitor-lectus-nibh.jpg"></a>
        <div class="gallery-item__caption">The Caption</div>
    </div>
    <div class="gallery-item">
        <a href="http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa-700x394.jpg"><img class="gallery-item__image" src="http://vagrant.byf1.io/wp-content/uploads/2017/08/praesent-sapien-massa-700x394.jpg"></a>
         <div class="gallery-item__caption">The Caption</div>
    </div>
</div>
```

This filter won't alter any other functionality on the site where Gesso theme is used, or load/use additional resources. This snippet of code only takes effect when used the default WordPress `[gallery]` shortcode in the WYSIWYG editor https://codex.wordpress.org/Gallery_Shortcode