### PR TITLE
Removing call to $wp_styles global

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -152,7 +152,6 @@ add_filter( 'wp_nav_menu', 'add_first_and_last' );
 
 
 function gesso_header_scripts() {
-  global $wp_styles;
 
   wp_deregister_script('jquery');
   wp_register_script('jquery', 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js', array() ); // Google CDN jQuery


### PR DESCRIPTION
 Seems that variable it's not even used within that function, then why pull that one in?