### PR TITLE
Placeholder block at base.twig for js scripts

### DIFF
--- a/templates/base.twig
+++ b/templates/base.twig
@@ -49,6 +49,9 @@
     {% include 'footer.twig' %}
     {{ function('wp_footer') }}
   {% endblock %}
+  
+  {% block javascripts %}
+  {% endblock %}
 
 </body>
 </html>


### PR DESCRIPTION
This is meant to be a block to hold javascript snippets that we can add from [template extends](https://twig.symfony.com/doc/2.x/tags/extends.html) files, e.g:

```html
<!-- File templates/archive-country.twig -->
{% extends "base.twig" %}

{% block content %}
<section>

	<!-- Render a JQVMap -->
	<div id="map-container" style="width: 100%; height: 500px;"></div>	
	
</section>
{% endblock %}

{% block javascripts %}
<script type="text/javascript">
	jQuery(document).ready(function() {
		jQuery('#map-container').vectorMap({ 
			map: 'world_en',
			enableZoom: false,
		});
	});
</script>
{% endblock %}
```

This way we are adding and executing JS code only from those pages where are needed, nor the entire site pages.