### PR TITLE
Add Text Domain for i18n support

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,7 @@ Author URI: http://forumone.com
 Tags:  responsive-layout, right-sidebar, two-columns, accessibility-ready, Timber, Twig, Forum One
 License:
 License URI:
+Text Domain: gesso
 */
 
 


### PR DESCRIPTION
See https://codex.wordpress.org/I18n_for_WordPress_Developers#Text_Domains. The addition of `Text Domain` in the theme's file header helps with translation support.